### PR TITLE
edit RocketProjectile Class

### DIFF
--- a/Content/Blueprints/BP_GJRocketProjectile.uasset
+++ b/Content/Blueprints/BP_GJRocketProjectile.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:769fae17f58c60d93234458f7080f88031aa0e4eef3575393a919d97c612cacd
-size 36100
+oid sha256:061bc5865140ddca260235f479fbca79797cf3c102eb95d3a66f73cc6524ffff
+size 36190

--- a/Source/GetToJob/Weapon/GJRocketProjectile.cpp
+++ b/Source/GetToJob/Weapon/GJRocketProjectile.cpp
@@ -127,7 +127,7 @@ void AGJRocketProjectile::AutoExplode()
 		GetActorLocation(),
 		DamageRadius,
 		nullptr,
-		OverlappedActors,
+		TArray<AActor*>(),
 		this,
 		GetInstigatorController(),
 		true


### PR DESCRIPTION
- 로켓 데미지 안 들어가는 버그 수정 (넉백 확인을 위해 BP_GJRocketProjectile의 DamageAmount를 1로 수정했습니다. 데미지를 올리려면 여기를 수정해주세요.)